### PR TITLE
BUG fix: merge in case of ffmpeg process killed

### DIFF
--- a/lib_ffmpeg.php
+++ b/lib_ffmpeg.php
@@ -304,7 +304,7 @@ function movie_extract_cutlist($movie_path, $movie_in, $cutlist_file, $movie_out
             // -y  : the segment is replaced if already existing
             $more_params = ($try >= 1) ? ' -probesize 1000000 -analyzeduration 1000000 ' : ''; // increase analyze duration
             $more_params .= ($try >= 2) ? ' -pix_fmt yuv420p ' : ''; // defines pixel format, which is often lacking
-            $cmd = "$ffmpeg_cli_cmd -i $movie_path/$movie_in -ss " . $part_start_second . " -t " . $desired_part_duration . $more_params . " -c copy -y $tmp_dir/part-$index.mov; wait";
+			$cmd = "$ffmpeg_cli_cmd -ss " . $part_start_second . " -i $movie_path/$movie_in  -t " . $desired_part_duration . $more_params . " -c copy -y $tmp_dir/part-$index.mov; wait";
             print "*************************************************************************" . PHP_EOL .
                     $cmd . PHP_EOL .
                     "*************************************************************************" . PHP_EOL;


### PR DESCRIPTION
put the -ss before the -i to avoid problem of void in the begining of
the part-0.mov file.